### PR TITLE
Added hyperlinks to docs.totaljs.com

### DIFF
--- a/blocks/readme.md
+++ b/blocks/readme.md
@@ -1,12 +1,12 @@
 ## Example: Blocks
 
-This example shows how to use blocks in HTML templates (views), CSS and JS files.
+This example shows how to use [Blocks](http://docs.totaljs.com/latest/en.html#pages~Blocks%20\(JS%2BCSS%2BHTML\)) in HTML templates (views), CSS and JS files.
 
 Features covered by this example:
 
-* `@{BLOCK}` and `@{END}` tags in CSS, JS and HTML files
-* `@{if}`, `@{fi}`, `@{else}` and `@{import}` tags in HTML files
-* `F.map()` method - clone files, enable blocks, merging files
+* [`@{BLOCK}`](http://docs.totaljs.com/latest/en.html#pages~Blocks%20\(JS%2BCSS%2BHTML\)) and [`@{END}`](http://docs.totaljs.com/latest/en.html#pages~Blocks%20\(JS%2BCSS%2BHTML\)) tags in CSS, JS and HTML files
+* `@{if}`, `@{fi}`, `@{else}` and [`@{import}`](http://docs.totaljs.com/latest/en.html#api~FrameworkViews~%40%7Bimport) tags in HTML files
+* [`F.map()`](http://docs.totaljs.com/latest/en.html#api~Framework~framework.map) method - clone files, enable blocks, merging files
 
 ### Overview
 

--- a/controller-cancel/readme.md
+++ b/controller-cancel/readme.md
@@ -4,15 +4,15 @@ This example shows how to use a framework event to intercept, cancel and redirec
 
 Features covered by this example:
 
-* Controllers - route URL requests to code
-* Definitions - coded config files
-* `F.route()` - define a route
-* `F.on('controller')` - intercept controller requests
-* `controller.cancel()` - cancel a request
-* `controller.redirect()` - redirect a request
-* `controller.url` - determine request path
-* `controller.transfer()` - transfer a request
-* `controller.isTransfer` - detect a transfer
+* [Controllers](http://docs.totaljs.com/latest/en.html#pages~Controllers) - route URL requests to code
+* [Definitions](http://docs.totaljs.com/latest/en.html#pages~Definitions) - coded config files
+* [`F.route()`](http://docs.totaljs.com/latest/en.html#api~Framework~framework.route) - define a route
+* [`F.on('controller')`](http://docs.totaljs.com/latest/en.html#api~Framework~framework.on('controller') - intercept controller requests
+* [`controller.cancel()`](http://docs.totaljs.com/latest/en.html#api~FrameworkController~controller.cancel) - cancel a request
+* [`controller.redirect()`](http://docs.totaljs.com/latest/en.html#api~FrameworkController~controller.redirect) - redirect a request
+* [`controller.url`](http://docs.totaljs.com/latest/en.html#api~FrameworkController~controller.url) - determine request path
+* [`controller.transfer()`](http://docs.totaljs.com/latest/en.html#api~FrameworkController~controller.transfer) - transfer a request
+* [`controller.isTransfer`](http://docs.totaljs.com/latest/en.html#api~FrameworkController~controller.isTransfer) - detect a transfer
 
 ### Routing
 

--- a/controller-mail/readme.md
+++ b/controller-mail/readme.md
@@ -7,14 +7,14 @@ This example shows how to create a URL that generates an email and then redirect
 
 Features covered by this example:
 
-* Controllers - route URL requests to code
-* Views - HTML template engine
+* [Controllers](http://docs.totaljs.com/latest/en.html#pages~Controllers) - route URL requests to code
+* [Views](http://docs.totaljs.com/latest/en.html#pages~View%20engine) - HTML template engine
 * Config - settings (mail server) used by the framework
-* `F.route()` - define a route
-* `controller.view()` - render a HTML template
-* `controller.mail()` - send an email
-* `controller.redirect()` - redirect a request
-* `@{layout`, `@{if}`, `@{fi}` and `{@model.key}` template tags
+* [`F.route()`](http://docs.totaljs.com/latest/en.html#api~Framework~framework.route) - define a route
+* [`controller.view()`](http://docs.totaljs.com/latest/en.html#api~FrameworkController~controller.view) - render a HTML template
+* [`controller.mail()`](http://docs.totaljs.com/latest/en.html#api~FrameworkController~controller.mail) - send an email
+* [`controller.redirect()`](http://docs.totaljs.com/latest/en.html#api~FrameworkController~controller.redirect) - redirect a request
+* [`@{layout`](http://docs.totaljs.com/latest/en.html#api~FrameworkViews~%40%7Blayout), `@{if}`, `@{fi}`, [`query.success`](http://docs.totaljs.com/latest/en.html#api~FrameworkViews~%40%7Bquery.customKey%7D) and [`{@model.key}`](http://docs.totaljs.com/latest/en.html#api~FrameworkViews~%40%7Bmodel.customKey%7D) template tags
 
 ### Overview
 


### PR DESCRIPTION
Note: Couldn't find any direct links for `@{if}`, `@{else}` or `@{fi}` - they are missing from the [Framework Views](http://docs.totaljs.com/latest/en.html#api~FrameworkViews) doc page.