### PR TITLE
check error first

### DIFF
--- a/workers/workers/xml.js
+++ b/workers/workers/xml.js
@@ -5,6 +5,11 @@ F.load('debug', ['config'], '../');
 
 U.download(CONFIG('url'), ['get'], function(err, response) {
 
+    if (err) {
+        console.error(err);
+        return process.exit();
+    }
+
 	var data = [];
 
 	response.on('data', U.streamer('<CD>', '</CD>', function(item) {


### PR DESCRIPTION
when error occurs, response object is null.

>  TypeError: Cannot read property 'on' of undefined TypeError: Cannot read property 'on' of undefined
    at Object.callback (E:\WorkSpace\examples\workers\workers\xml.js:10:10)
    at ClientRequest.<anonymous> (E:\WorkSpace\node_modules\total.js\utils.js:901:11)
    at emitOne (events.js:96:13)
    at ClientRequest.emit (events.js:188:7)
    at Socket.socketErrorListener (_http_client.js:310:9)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at connectErrorNT (net.js:1020:8)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
